### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sdxv.yml
+++ b/.github/workflows/sdxv.yml
@@ -3,6 +3,9 @@ name: SDVX Profile Extractor
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   cypress-run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Bamuel/SDVX-Profile-Extractor/security/code-scanning/1](https://github.com/Bamuel/SDVX-Profile-Extractor/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow to explicitly define the minimal permissions required. Based on the workflow's operations, the following permissions are necessary:
- `contents: read` for checking out the repository code.
- `contents: write` for uploading artifacts and deploying files via SCP.

This ensures that the workflow has only the permissions it needs and no more.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
